### PR TITLE
Put feedback items in report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,11 @@ import './App.scss';
 import Header from './Components/Header/Header';
 import Checker from './Components/Main/Checker';
 import ReportPanel from './Components/Main/ReportPanel';
-import { PlainLanguageProblem, ReportType } from './Types';
+import { FeedbackData, FeedbackType } from './Types';
 import { Text } from './Parser/Parser';
 
 function App(): JSX.Element {
-	const [possibleProblemList, setPossibleProblemList] = useState<PlainLanguageProblem[]>([]);
+	const [possibleProblemList, setPossibleProblemList] = useState<FeedbackData[]>([]);
 
 	const onClickSubmit = (article: string) => {
 		console.log(article);
@@ -34,26 +34,19 @@ function App(): JSX.Element {
 		console.log('---------- Kudos ----------');
 		console.log(parsedText.getKudos());
 
-		//ToDo: run plain language checker
-		let list: PlainLanguageProblem[] = [
-			{
-				type: ReportType.niceToHave,
-				title: 'Use Transistion Words', 
-				occurrence: 10	
-			},
-			{
-				type: ReportType.warning,
-				title: 'Use Positive Words', 
-				occurrence: 5	
-			},
-			{
-				type: ReportType.error,
-				title: 'Use Abbreviation', 
-				occurrence: 2	
-			}
-
-		];
-		list = list.sort(item => item.occurrence);
+		const list: FeedbackData[] = [];
+		for (const issue of parsedText.getIssues())
+		{
+			list.push(issue.getData());
+		}
+		for (const suggestion of parsedText.getSuggestions())
+		{
+			list.push(suggestion.getData());
+		}
+		for (const kudo of parsedText.getKudos())
+		{
+			list.push(kudo.getData());
+		}
 		setPossibleProblemList(list);
 	};
 

--- a/src/Components/Main/ReportPanel.tsx
+++ b/src/Components/Main/ReportPanel.tsx
@@ -4,7 +4,7 @@ import {
 	AccordionItem
 } from '@carbon/react';
 import './ReportPanel.scss';
-import { PlainLanguageProblem, ReportType } from '../../Types';
+import { FeedbackData, FeedbackType } from '../../Types';
 
 
 function ReportPanel(props: ReportPanelPropsType): JSX.Element {
@@ -13,17 +13,29 @@ function ReportPanel(props: ReportPanelPropsType): JSX.Element {
 	return (
 		<div className='report-panel'>
 			<h2>Suggestions</h2>
-			<p className='subtitle'>We found {items.length} additional words</p>
+			<p className='subtitle'>We found {items.length} feedback items.</p>
 			<Accordion className='report-list'>
 				{items.map( (item, index) => {
-					const {type, title, occurrence } = item;
+					const {name, feedbackType, link, linkText, description, matchedString, stringSuggestion, paragraphNumber, sentenceNumber } = item;
 					return (
 
 						<AccordionItem 
 							key={index}
-							title={`${occurrence} ${title}`}>
+							title={`${feedbackType}: ${name}`}>
 							<p>
-								{type}
+								{ `Location: Paragraph ${paragraphNumber}, Sentence ${sentenceNumber}` }
+							</p>
+							<p>
+								{ `Description: ${description}` }
+							</p>
+							<p>
+								{ `More information at <a href="${link}">${linkText}</a>` }
+							</p>
+							<p>
+								{ `Matched word(s): ${matchedString}` }
+							</p>
+							<p>
+								{ `Suggestion: ${stringSuggestion}` }
 							</p>
 						</AccordionItem>
 
@@ -36,6 +48,6 @@ function ReportPanel(props: ReportPanelPropsType): JSX.Element {
 }
 
 type ReportPanelPropsType = {
-    items: PlainLanguageProblem[]
+    items: FeedbackData[]
 }
 export default ReportPanel;

--- a/src/Parser/Parser.ts
+++ b/src/Parser/Parser.ts
@@ -1,3 +1,5 @@
+import { FeedbackData, FeedbackType } from '../Types/index';
+
 export class Text {
 	private text: string;  // can be removed, leave for debugging
 	private paragraphs: Paragraph[];
@@ -369,24 +371,8 @@ export class Sentence {
 
 }
 
-export enum FeedbackType {
-	Issue = 'Issue',
-	Suggestion = 'Suggestion',
-	Kudo = 'Kudo',
-}
-
 export class Feedback {
-	private name: string;
-	private link: string;
-	private linkText: string;
-	private description: string;
-	private matchedString: string;
-	private stringSuggestion: string;
-	private feedbackType: string;
-	private paragraphNumber: number;
-	private sentenceNumber: number;
-	// TODO: Add more information here. We could list the words in the context or just say a word number in the sentence
-	// https://github.com/yichiang/plain-language-checker/issues/33
+	private data: FeedbackData;
 	constructor(
 		name: string,
 		feedbackType: FeedbackType,
@@ -398,16 +384,22 @@ export class Feedback {
 		matchedString: string,
 		stringSuggestion = ''
 	) {
-		this.name = name;
-		this.feedbackType = feedbackType;
-		this.link = link;
-		this.linkText = linkText;
-		this.description = description;
-		this.paragraphNumber = paragraphNumber;
-		this.sentenceNumber = sentenceNumber;
-		// The values below are set by the parsing function
-		this.matchedString = matchedString; // String that matched a keyword
-		this.stringSuggestion = stringSuggestion; // Other word(s) suggestions, may be empty
+		this.data = {
+			name: name,
+			feedbackType: feedbackType,
+			link: link,
+			linkText: linkText,
+			description: description,
+			paragraphNumber: paragraphNumber,
+			sentenceNumber: sentenceNumber,
+			matchedString: matchedString, // String that matched a keyword
+			stringSuggestion: stringSuggestion // Other word(s) suggestions, may be empty
+		};
+	}
+
+	// Getters
+	getData (): FeedbackData {
+		return this.data;
 	}
 }
 

--- a/src/Types/index.tsx
+++ b/src/Types/index.tsx
@@ -1,14 +1,19 @@
-
-
-export enum ReportType {
-    warning,
-    error,
-    info,
-    niceToHave
+export enum FeedbackType {
+	Issue = 'Issue',
+	Suggestion = 'Suggestion',
+	Kudo = 'Kudo',
 }
 
-export type PlainLanguageProblem = {
-    type: ReportType;
-    title: string;
-    occurrence: number;
+// TODO: Add more information here. We could list the words in the context or just say a word number in the sentence
+// https://github.com/yichiang/plain-language-checker/issues/33
+export type FeedbackData = {
+    name: string;
+    feedbackType: FeedbackType;
+    link: string;
+    linkText: string;
+    description: string;
+    matchedString: string;
+    stringSuggestion: string;    
+    paragraphNumber: number;
+    sentenceNumber: number;
 }


### PR DESCRIPTION
This PR ties together the Feedback data from the UI (report) and the parser. We now report the feedback items as long with the data.

We still need to:
- Group by issue, suggestion, kudo
- Fix the hyperlink in the feedback item
- Don't include "Suggestion:" if there isn't any
- Instead of saying "We found 10 feedback items." we could say "We found %d issues, %d suggestions and %d kudos"

![image](https://user-images.githubusercontent.com/49347521/221397000-7ed29ad7-fa5a-4d2e-a429-d17b04cd905b.png)
