### PR TITLE
Convert tabs to spaces, minor fixes

### DIFF
--- a/src/Parser/Parser.ts
+++ b/src/Parser/Parser.ts
@@ -7,7 +7,7 @@ import reportSyllableHighCount from './Validator/SyllableCount';
 import { wordListArray } from './WordList';
 
 const maxNumberOfWordsInSentence = 35;
-const maxNumberOfSentencesInParaghraph = 10;
+const maxNumberOfSentencesInParaghraph = 7;
 
 export class Text {
 	private text: string;  // can be removed, leave for debugging
@@ -18,6 +18,8 @@ export class Text {
 		this.text = text.replace(/[\r\n]+/gi, '\n');
 		// Remove trailing linebreaks
 		this.text = this.text.replace(/[\r\n]+$/gi, '').trim();
+		// Convert tabs to spaces
+		this.text = this.text.replace(/[\t]+/gi, ' ');
 		// Split in paragraphs
 		const paragraphsText = this.text.split('\n');
 		this.paragraphs = [];

--- a/src/Parser/Validator/SlashChecker.ts
+++ b/src/Parser/Validator/SlashChecker.ts
@@ -1,7 +1,7 @@
 import { Suggestion } from '../Parser';
 import { Sentence } from '../Sentence';
 
-const wordList = ['and/or', 'w/o', 'w/'];
+const wordList = ['and/or', 'or/and', 'w/o', '/'];
 export default function reportSlashUsage(sentence: Sentence) {
 	const match: string[] = [];
 	wordList.forEach(word => {
@@ -9,17 +9,23 @@ export default function reportSlashUsage(sentence: Sentence) {
 			match.push(word);
 		}
 	});
+	if (match.length > 1 && match[match.length-1] === '/')
+	{
+		// Remove slash if it was detected and we also have another match.
+		match.pop();
+	}
+
 	if(match.length > 0) {
 		sentence.getSuggestions().push(new Suggestion(
 			'Don’t use slashes', 
 			'https://www.plainlanguage.gov/guidelines/conversational/dont-use-slashes/',
 			'Don’t use slashes - Plain language guidelines',
-			'The sentence contains and/or or w/o. Please check whether we can replace it.',
+			`The sentence contains ${match.join(',')}.`,
 			sentence.getParagraphNumber(),
 			sentence.getSentenceNumber(),
 			`${match.join(',')}`,
-			`consider checking the usage of slash for ${match.join(',')}.`
-		));        
+			'Please consider replacing the slash with words.'
+		));
 	}
 
 }

--- a/src/Parser/Validator/SyllableCount.ts
+++ b/src/Parser/Validator/SyllableCount.ts
@@ -3,7 +3,7 @@ import { Suggestion } from '../Parser';
 import { Sentence } from '../Sentence';
 
 const highCount = 5;
-export default function reportSyllableHighCount(sentence: Sentence, checkForBy = false) {
+export default function reportSyllableHighCount(sentence: Sentence) {
 	const issues: {word: string, count: number}[] = [];
 	sentence.getWords().forEach(word => {
 		const count = syllable(word);
@@ -13,17 +13,16 @@ export default function reportSyllableHighCount(sentence: Sentence, checkForBy =
 	});
 	const words = issues.map(issue=> `${issue.word}`);
 	const wordList = words.join(',');
-	console.log(wordList);
 	if(issues.length > 0) {
 		sentence.getSuggestions().push(new Suggestion(
 			'Use simple words and phrases', 
 			'https://www.plainlanguage.gov/guidelines/words/use-simple-words-phrases/',
 			'Use simple words and phrases - Plain language guidelines',
-			`The sentence contains ${wordList} with high syllable count. Please consider to change if the word might be complicated.`,
+			`The sentence contains the following high-syllable words: ${wordList}.`,
 			sentence.getParagraphNumber(),
 			sentence.getSentenceNumber(),
 			wordList || '',
-			`Consider replacing "${wordList}" with simple word.`
+			`Please consider replacing "${wordList}" with simpler words.`
 		));        
 	}
 


### PR DESCRIPTION
Convert tabs to spaces, minor fixes:

- Change `maxNumberOfSentencesInParaghraph` from 10 to 7.
- Convert tabs to spaces so we can correctly parse text with Tabs '/t'.
- Minor changes to the slash check function to check for single slash.
- Rephrase suggestions in syllable checker and slash checker.